### PR TITLE
Allow using `--startMs` for long preparations

### DIFF
--- a/dora/stress/common/src/main/java/alluxio/stress/BaseParameters.java
+++ b/dora/stress/common/src/main/java/alluxio/stress/BaseParameters.java
@@ -89,7 +89,7 @@ public final class BaseParameters {
 
   @Parameter(names = {START_MS_FLAG},
       description = "The time (ms since epoch) in the future to start the test. -1 means start "
-          + "immediately.", hidden = true)
+          + "5 seconds later.", hidden = true)
   public long mStartMs = UNDEFINED_START_MS;
 
   @Parameter(names = {IN_PROCESS_FLAG},

--- a/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
+++ b/dora/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
@@ -408,6 +408,8 @@ public class StressWorkerBench extends AbstractStressBench<WorkerBenchTaskResult
     long startMs = mBaseParameters.mStartMs;
     if (mBaseParameters.mStartMs == BaseParameters.UNDEFINED_START_MS) {
       startMs = CommonUtils.getCurrentMs() + 5000;
+    } else {
+      startMs = CommonUtils.getCurrentMs() + startMs;
     }
     long endMs = startMs + warmupMs + durationMs;
     BenchContext context = new BenchContext(startMs, endMs);


### PR DESCRIPTION
The `currentMs` would not be added to `startMs` when the `startMs` has been set, and this will cause test fail.
Now fixed.